### PR TITLE
Compile is deprecated and so I replace with implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ buildscript {
   }
 }
 
-compile('org.rabbit-converter.rabbit:rabbit:0.0.3') {
+implementation('org.rabbit-converter.rabbit:rabbit:0.0.3') {
   exclude group: 'org.json', module: 'json'
 }
 ```


### PR DESCRIPTION
In download section of read me, I replaced compile with implementation because compile is deprecated.